### PR TITLE
Remove usage of deprecated IOException2

### DIFF
--- a/drools/src/main/java/hudson/drools/DroolsSession.java
+++ b/drools/src/main/java/hudson/drools/DroolsSession.java
@@ -1,7 +1,6 @@
 package hudson.drools;
 
 import hudson.security.ACL;
-import hudson.util.IOException2;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -43,7 +42,7 @@ import org.drools.runtime.StatefulKnowledgeSession;
 public class DroolsSession {
 
 	private static Logger LOGGER = Logger.getLogger(DroolsSession.class.getName());
-	
+
 	private final StatefulKnowledgeSession session;
 	private final KnowledgeBase kbase;
 	private final Marshaller marshaller;
@@ -108,10 +107,10 @@ public class DroolsSession {
 				is = new FileInputStream(saved);
 				session = marshaller.unmarshall(is, conf, env);
 			} catch (ClassNotFoundException e) {
-				throw new IOException2("Class not found while unmarshalling "
+				throw new IOException("Class not found while unmarshalling "
 						+ saved.getAbsolutePath(), e);
 			} catch (IOException e) {
-				throw new IOException2("Error while unmarshalling "
+				throw new IOException("Error while unmarshalling "
 						+ saved.getAbsolutePath(), e);
 			} finally {
 				is.close();

--- a/drools/src/main/java/hudson/drools/HumanTask.java
+++ b/drools/src/main/java/hudson/drools/HumanTask.java
@@ -28,7 +28,6 @@ import org.acegisecurity.AccessDeniedException;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
-import org.kohsuke.stapler.framework.io.IOException2;
 
 public class HumanTask extends AbstractModelObject implements AccessControlled {
 
@@ -85,17 +84,17 @@ public class HumanTask extends AbstractModelObject implements AccessControlled {
 						((BooleanParameterValue) value).value);
 			}
 		}
-		
+
 		PrintWriter log = run.getLogWriter();
 		log.println("HumanTask " + displayName + " #" + workItemId + " submitted.");
 		log.println("\tUser: " + Hudson.getAuthentication().getName());
 		log.println("\tResults: " + results);
-		
+
 		try {
 			run.getParent().run(
 					new CompleteWorkItemCallable(workItemId, results));
 		} catch (Exception e) {
-			throw new IOException2("Error while completing human task #"
+			throw new IOException("Error while completing human task #"
 					+ workItemId, e);
 		}
 


### PR DESCRIPTION
## Remove usage of deprecated IOException2

Removes usage of deprecated `hudson.util.IOException2` and `org.kohsuke.stapler.framework.io.IOException2` by replacing it with `java.io.IOException`

### Testing done

None, rely on `ci.jenkins.io` to test it.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
